### PR TITLE
Update purefa_pgsnap.py for vgroup check

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
@@ -231,7 +231,7 @@ def restore_pgsnapvolume(module, array):
             if get_pgroupvolume(module, array) is None:
                 module.fail_json(msg="Selected restore volume {0} does not exist in the Protection Group".format(module.params['restore']))
         if "/" in module.params['restore'] and not check_vgroup(module, array):
-            module.fail_json(msg="Failed to create volume {0}. Volume Group does not exist.".format(module.params["name"]))
+            module.fail_json(msg="Failed to create volume {0}. Volume Group does not exist.".format(module.params["restore"]))
         volume = module.params['name'] + "." + module.params['suffix'] + "." + module.params['restore']
         try:
             array.copy_volume(volume, module.params['target'], overwrite=module.params['overwrite'])

--- a/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
@@ -137,6 +137,7 @@ from ansible.module_utils.pure import get_system, purefa_argument_spec
 
 from datetime import datetime
 
+VGROUPS_API_VERSION = "1.13"
 
 def get_pgroup(module, array):
     """Return Protection Group or None"""
@@ -178,6 +179,25 @@ def get_pgsnapshot(module, array):
     except Exception:
         return None
 
+      
+def check_vgroup(module, array):
+    """Check is the requested VG to create volume in exists"""
+    vg_exists = False
+    api_version = array._list_available_rest_versions()
+    if VGROUPS_API_VERSION in api_version:
+        vg_name = module.params["name"].split("/")[0]
+        try:
+            vgs = array.list_vgroups()
+        except Exception:
+            module.fail_json(msg="Failed to get volume groups list. Check array.")
+        for vgroup in range(0, len(vgs)):
+            if vg_name == vgs[vgroup]['name']:
+                vg_exists = True
+                break
+    else:
+        module.fail_json(msg="VG volumes are not supported. Please upgrade your FlashArray.")
+    return vg_exists
+
 
 def create_pgsnapshot(module, array):
     """Create Protection Group Snapshot"""
@@ -210,6 +230,8 @@ def restore_pgsnapvolume(module, array):
         else:
             if get_pgroupvolume(module, array) is None:
                 module.fail_json(msg="Selected restore volume {0} does not exist in the Protection Group".format(module.params['restore']))
+        if "/" in module.params['restore'] and not check_vgroup(module, array):
+            module.fail_json(msg="Failed to create volume {0}. Volume Group does not exist.".format(module.params["name"]))
         volume = module.params['name'] + "." + module.params['suffix'] + "." + module.params['restore']
         try:
             array.copy_volume(volume, module.params['target'], overwrite=module.params['overwrite'])

--- a/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
@@ -185,7 +185,7 @@ def check_vgroup(module, array):
     vg_exists = False
     api_version = array._list_available_rest_versions()
     if VGROUPS_API_VERSION in api_version:
-        vg_name = module.params["name"].split("/")[0]
+        vg_name = module.params["restore"].split("/")[0]
         try:
             vgs = array.list_vgroups()
         except Exception:

--- a/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
@@ -231,7 +231,7 @@ def restore_pgsnapvolume(module, array):
             if get_pgroupvolume(module, array) is None:
                 module.fail_json(msg="Selected restore volume {0} does not exist in the Protection Group".format(module.params['restore']))
         if "/" in module.params['restore'] and not check_vgroup(module, array):
-            module.fail_json(msg="Failed to create volume {0}. Volume Group does not exist.".format(module.params["restore"]))
+            module.fail_json(msg="Failed to restore volume {0}. Volume Group does not exist.".format(module.params["restore"]))
         volume = module.params['name'] + "." + module.params['suffix'] + "." + module.params['restore']
         try:
             array.copy_volume(volume, module.params['target'], overwrite=module.params['overwrite'])


### PR DESCRIPTION
Update to restore_pgsnapvolume to check if the volume is in a vgroup and the vgroup exists at the destination. Used existing code from purefa_volume.py for the vgroup check.

##### SUMMARY
Current version of restore_pgsnapvolume does not check for the existence of a volume group at the destination. If the volume group does not exist, the command will fail with a generic "Failed to restore" message. 
Added the same logic to check for a volume group as was used in purefa_volume.py. Now if the creation fails, the error message shows "Failed to create volume xyz. Volume Group does not exist"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pgsnap.py - restore_pgsnapvolume

##### ADDITIONAL INFORMATION
Error before update:
```
"Failed to restore PSBOT:mysqldemo.20190801T075627.vvol-mysql-b4ec20d1-vg/Data-e0e1b633 from pgroup PSBOT:mysqldemo"
```
Error after update:
```
"Failed to restore volume vvol-mysql-b4ec20d1-vg/Data-e0e1b633. Volume Group does not exist."
```
